### PR TITLE
Create Runner Abstraction and Various Bug Fixes

### DIFF
--- a/Benchmark/Faultify.Benchmark.NUnit/BenchmarkNUnit.cs
+++ b/Benchmark/Faultify.Benchmark.NUnit/BenchmarkNUnit.cs
@@ -1,17 +1,18 @@
+using System.IO;
 using Faultify.Benchmark;
 using Faultify.Benchmark_0;
 using NUnit.Framework;
 
 namespace Faultify.Benchmark.NUnit
 {
-    public class BenchmarkNUnit
+    public class BenchmarkXUnit
     {
         [Test]
         public void TestArray()
         {
             var targets = new BenchmarkTarget();
             var actual = targets.ConstructArray();
-            int[] expected = {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
+            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
 
             Assert.AreEqual(expected, expected);
         }
@@ -66,7 +67,7 @@ namespace Faultify.Benchmark.NUnit
         {
             var targets = new BenchmarkTarget();
             targets.ForLoop(10);
-            Assert.IsTrue(true);
+            Assert.True(true);
         }
 
         [Test]
@@ -122,6 +123,378 @@ namespace Faultify.Benchmark.NUnit
         public void TestLogicalOr()
         {
             var targets = new BenchmarkTarget();
+            var actual = targets.LogicalOr(0, 1);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+    }
+
+    public class BenchmarkXUnit1
+    {
+        [Test]
+        public void TestArray()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.ConstructArray();
+            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+
+            Assert.AreEqual(expected, expected);
+        }
+
+        [Test]
+        public void TestAddition()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Addition(5, 4);
+            var expected = 9;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestSubtraction()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Subtraction(5, 4);
+            var expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDivision()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Division(2, 1);
+            var expected = 2;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestMultiplication()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Multiplication(2, 2);
+            var expected = 4;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestModulo()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Modulo(3, 2);
+            var expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestForLoop()
+        {
+            var targets = new BenchmarkTarget1();
+            targets.ForLoop(10);
+            Assert.True(true);
+        }
+
+        [Test]
+        public void TestWhileLoop()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.WhileLoop(10);
+            var expected = 10;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestIf()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.If(true);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLessThan()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = false;
+
+            actual = targets.LessThan(5, 10);
+
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestMoreThan()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.MoreThan(10, 5);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLogicalAnd()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.LogicalAnd(0, 0);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [Test]
+        public void TestLogicalOr()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.LogicalOr(0, 1);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+    }
+
+    public class BenchmarkXUnit2
+    {
+        [Test]
+        public void TestArray()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.ConstructArray();
+            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+
+            Assert.AreEqual(expected, expected);
+        }
+
+        [Test]
+        public void TestAddition()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Addition(5, 4);
+            var expected = 9;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestSubtraction()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Subtraction(5, 4);
+            var expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDivision()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Division(2, 1);
+            var expected = 2;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestMultiplication()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Multiplication(2, 2);
+            var expected = 4;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestModulo()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Modulo(3, 2);
+            var expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestForLoop()
+        {
+            var targets = new BenchmarkTarget2();
+            targets.ForLoop(10);
+            Assert.True(true);
+        }
+
+        [Test]
+        public void TestWhileLoop()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.WhileLoop(10);
+            var expected = 10;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestIf()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.If(true);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLessThan()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = false;
+
+            actual = targets.LessThan(5, 10);
+
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestMoreThan()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.MoreThan(10, 5);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLogicalAnd()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.LogicalAnd(0, 0);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [Test]
+        public void TestLogicalOr()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.LogicalOr(0, 1);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+    }
+
+    public class BenchmarkXUnit3
+    {
+        [Test]
+        public void TestArray()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.ConstructArray();
+            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+
+            Assert.AreEqual(expected, expected);
+        }
+
+        [Test]
+        public void TestAddition()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Addition(5, 4);
+            var expected = 9;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestSubtraction()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Subtraction(5, 4);
+            var expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDivision()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Division(2, 1);
+            var expected = 2;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestMultiplication()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Multiplication(2, 2);
+            var expected = 4;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestModulo()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Modulo(3, 2);
+            var expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestForLoop()
+        {
+            var targets = new BenchmarkTarget3();
+            targets.ForLoop(10);
+            Assert.True(true);
+        }
+
+        [Test]
+        public void TestWhileLoop()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.WhileLoop(10);
+            var expected = 10;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestIf()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.If(true);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLessThan()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = false;
+
+            actual = targets.LessThan(5, 10);
+
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestMoreThan()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.MoreThan(10, 5);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestLogicalAnd()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.LogicalAnd(0, 0);
+            var expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [Test]
+        public void TestLogicalOr()
+        {
+            var targets = new BenchmarkTarget3();
             var actual = targets.LogicalOr(0, 1);
             var expected = true;
             Assert.AreEqual(expected, actual);

--- a/Benchmark/Faultify.Benchmark.NUnit/BenchmarkNUnit.cs
+++ b/Benchmark/Faultify.Benchmark.NUnit/BenchmarkNUnit.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using Faultify.Benchmark;
 using Faultify.Benchmark_0;
 using NUnit.Framework;
 
@@ -12,7 +10,7 @@ namespace Faultify.Benchmark.NUnit
         {
             var targets = new BenchmarkTarget();
             var actual = targets.ConstructArray();
-            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+            int[] expected = {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
 
             Assert.AreEqual(expected, expected);
         }
@@ -136,7 +134,7 @@ namespace Faultify.Benchmark.NUnit
         {
             var targets = new BenchmarkTarget1();
             var actual = targets.ConstructArray();
-            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+            int[] expected = {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
 
             Assert.AreEqual(expected, expected);
         }
@@ -260,7 +258,7 @@ namespace Faultify.Benchmark.NUnit
         {
             var targets = new BenchmarkTarget2();
             var actual = targets.ConstructArray();
-            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+            int[] expected = {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
 
             Assert.AreEqual(expected, expected);
         }
@@ -384,7 +382,7 @@ namespace Faultify.Benchmark.NUnit
         {
             var targets = new BenchmarkTarget3();
             var actual = targets.ConstructArray();
-            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+            int[] expected = {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
 
             Assert.AreEqual(expected, expected);
         }

--- a/Benchmark/Faultify.Benchmark.Runner/Program.cs
+++ b/Benchmark/Faultify.Benchmark.Runner/Program.cs
@@ -1,22 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Faultify.Benchmark.Runner
 {
-    class Program
+    internal class Program
     {
-        private static double stryker_found_mutations = 31.0;
-        private static double faultify_found_mutations = 29;
+        private static readonly double stryker_found_mutations = 31.0;
+        private static readonly double faultify_found_mutations = 29;
 
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             var elapsedFaultify = BenchmarkFaultify();
-            
+
             foreach (var elapse in elapsedFaultify)
             {
-                double mps = (faultify_found_mutations / TimeSpan.FromMilliseconds(elapse.Item2).Seconds);
+                var mps = faultify_found_mutations / TimeSpan.FromMilliseconds(elapse.Item2).Seconds;
                 Console.WriteLine($"Threads: {elapse.Item1} Time: {elapse.Item2} Mps: {mps:0.00}");
             }
 
@@ -24,7 +23,7 @@ namespace Faultify.Benchmark.Runner
 
             foreach (var elapse in elapsedStryker)
             {
-                double mps = (stryker_found_mutations / TimeSpan.FromMilliseconds(elapse.Item2).Seconds);
+                var mps = stryker_found_mutations / TimeSpan.FromMilliseconds(elapse.Item2).Seconds;
                 Console.WriteLine($"Threads: {elapse.Item1} Time: {elapse.Item2} Mps: {mps:0.00}");
             }
 
@@ -34,12 +33,13 @@ namespace Faultify.Benchmark.Runner
 
         private static List<(int, long)> BenchmarkStryker()
         {
-            List<(int, long)> elapsed = new List<(int, long)>();
+            var elapsed = new List<(int, long)>();
 
-            for (int i = 1; i < 7; i++)
+            for (var i = 1; i < 7; i++)
             {
-                string a = "\"['Faultify.Benchmark.NUnit\\\\Faultify.Benchmark.NUnit.csproj']\"";
-                string strykerConfig = $"stryker -tp {a} --project-file=Faultify.Benchmark\\Faultify.Benchmark.csproj -c " + i;
+                var a = "\"['Faultify.Benchmark.NUnit\\\\Faultify.Benchmark.NUnit.csproj']\"";
+                var strykerConfig =
+                    $"stryker -tp {a} --project-file=Faultify.Benchmark\\Faultify.Benchmark.csproj -c " + i;
 
                 var st = Stopwatch.StartNew();
                 Console.WriteLine(strykerConfig);
@@ -60,15 +60,17 @@ namespace Faultify.Benchmark.Runner
 
         private static List<(int, long)> BenchmarkFaultify()
         {
-            List<(int, long)> elapsed = new List<(int, long)>();
+            var elapsed = new List<(int, long)>();
 
-            for (int i = 1; i < 7; i++)
+            for (var i = 1; i < 7; i++)
             {
-                string faultifyConfig = @" -t ..\..\..\..\Faultify.Benchmark.NUnit\Faultify.Benchmark.NUnit.csproj -f html -p " + i;
+                var faultifyConfig =
+                    @" -t ..\..\..\..\Faultify.Benchmark.NUnit\Faultify.Benchmark.NUnit.csproj -f html -p " + i;
 
                 var st = Stopwatch.StartNew();
 
-                var process = Process.Start(@"..\..\..\..\..\Faultify.Cli\bin\Debug\netcoreapp3.1\Faultify.Cli.exe", faultifyConfig);
+                var process = Process.Start(@"..\..\..\..\..\Faultify.Cli\bin\Debug\netcoreapp3.1\Faultify.Cli.exe",
+                    faultifyConfig);
                 process.WaitForExit();
 
                 st.Stop();

--- a/Benchmark/Faultify.Benchmark.Runner/Program.cs
+++ b/Benchmark/Faultify.Benchmark.Runner/Program.cs
@@ -7,13 +7,25 @@ namespace Faultify.Benchmark.Runner
 {
     class Program
     {
+        private static double stryker_found_mutations = 31.0;
+        private static double faultify_found_mutations = 29;
+
         static void Main(string[] args)
         {
-            var elapsed = BenchmarkFaultify();
-
-            foreach (var elapse in elapsed)
+            var elapsedFaultify = BenchmarkFaultify();
+            
+            foreach (var elapse in elapsedFaultify)
             {
-                Console.WriteLine($"Threads: {elapse.Item1} Time: {elapse.Item2}");
+                double mps = (faultify_found_mutations / TimeSpan.FromMilliseconds(elapse.Item2).Seconds);
+                Console.WriteLine($"Threads: {elapse.Item1} Time: {elapse.Item2} Mps: {mps:0.00}");
+            }
+
+            var elapsedStryker = BenchmarkStryker();
+
+            foreach (var elapse in elapsedStryker)
+            {
+                double mps = (stryker_found_mutations / TimeSpan.FromMilliseconds(elapse.Item2).Seconds);
+                Console.WriteLine($"Threads: {elapse.Item1} Time: {elapse.Item2} Mps: {mps:0.00}");
             }
 
 
@@ -27,13 +39,13 @@ namespace Faultify.Benchmark.Runner
             for (int i = 1; i < 7; i++)
             {
                 string a = "\"['Faultify.Benchmark.NUnit\\\\Faultify.Benchmark.NUnit.csproj']\"";
-                string strykerConfig = $"stryker -tp {a} --project-file=Faultify.Benchmark_0\\Faultify.Benchmark_0.csproj -c " + i;
+                string strykerConfig = $"stryker -tp {a} --project-file=Faultify.Benchmark\\Faultify.Benchmark.csproj -c " + i;
 
                 var st = Stopwatch.StartNew();
                 Console.WriteLine(strykerConfig);
                 var process = new Process();
                 process.StartInfo = new ProcessStartInfo("dotnet", strykerConfig);
-                process.StartInfo.WorkingDirectory = "..\\..\\..\\..\\Benchmark\\";
+                process.StartInfo.WorkingDirectory = @"..\..\..\..\";
 
                 process.Start();
 
@@ -52,11 +64,11 @@ namespace Faultify.Benchmark.Runner
 
             for (int i = 1; i < 7; i++)
             {
-                string faultifyConfig = @" -t ..\..\..\..\Benchmark\Faultify.Benchmark.NUnit\Faultify.Benchmark.NUnit.csproj -f html -p " + i;
+                string faultifyConfig = @" -t ..\..\..\..\Faultify.Benchmark.NUnit\Faultify.Benchmark.NUnit.csproj -f html -p " + i;
 
                 var st = Stopwatch.StartNew();
 
-                var process = Process.Start(@"..\..\..\..\Faultify.Cli\bin\Debug\netcoreapp3.1\Faultify.Cli.exe", faultifyConfig);
+                var process = Process.Start(@"..\..\..\..\..\Faultify.Cli\bin\Debug\netcoreapp3.1\Faultify.Cli.exe", faultifyConfig);
                 process.WaitForExit();
 
                 st.Stop();

--- a/Benchmark/Faultify.Benchmark.XUnit/BenchmarkNUnit.cs
+++ b/Benchmark/Faultify.Benchmark.XUnit/BenchmarkNUnit.cs
@@ -134,7 +134,7 @@ namespace Faultify.Benchmark.XUnit
         {
             var targets = new BenchmarkTarget1();
             var actual = targets.ConstructArray();
-            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+            int[] expected = {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
 
             Assert.Equal(expected, expected);
         }
@@ -258,7 +258,7 @@ namespace Faultify.Benchmark.XUnit
         {
             var targets = new BenchmarkTarget2();
             var actual = targets.ConstructArray();
-            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+            int[] expected = {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
 
             Assert.Equal(expected, expected);
         }
@@ -382,7 +382,7 @@ namespace Faultify.Benchmark.XUnit
         {
             var targets = new BenchmarkTarget3();
             var actual = targets.ConstructArray();
-            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+            int[] expected = {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
 
             Assert.Equal(expected, expected);
         }

--- a/Benchmark/Faultify.Benchmark.XUnit/BenchmarkNUnit.cs
+++ b/Benchmark/Faultify.Benchmark.XUnit/BenchmarkNUnit.cs
@@ -126,4 +126,376 @@ namespace Faultify.Benchmark.XUnit
             Assert.Equal(expected, actual);
         }
     }
+
+    public class BenchmarkXUnit1
+    {
+        [Fact]
+        public void TestArray()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.ConstructArray();
+            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+
+            Assert.Equal(expected, expected);
+        }
+
+        [Fact]
+        public void TestAddition()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Addition(5, 4);
+            var expected = 9;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestSubtraction()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Subtraction(5, 4);
+            var expected = 1;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDivision()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Division(2, 1);
+            var expected = 2;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestMultiplication()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Multiplication(2, 2);
+            var expected = 4;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestModulo()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.Modulo(3, 2);
+            var expected = 1;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestForLoop()
+        {
+            var targets = new BenchmarkTarget1();
+            targets.ForLoop(10);
+            Assert.True(true);
+        }
+
+        [Fact]
+        public void TestWhileLoop()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.WhileLoop(10);
+            var expected = 10;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestIf()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.If(true);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestLessThan()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = false;
+
+            actual = targets.LessThan(5, 10);
+
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestMoreThan()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.MoreThan(10, 5);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestLogicalAnd()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.LogicalAnd(0, 0);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Fact]
+        public void TestLogicalOr()
+        {
+            var targets = new BenchmarkTarget1();
+            var actual = targets.LogicalOr(0, 1);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    public class BenchmarkXUnit2
+    {
+        [Fact]
+        public void TestArray()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.ConstructArray();
+            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+
+            Assert.Equal(expected, expected);
+        }
+
+        [Fact]
+        public void TestAddition()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Addition(5, 4);
+            var expected = 9;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestSubtraction()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Subtraction(5, 4);
+            var expected = 1;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDivision()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Division(2, 1);
+            var expected = 2;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestMultiplication()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Multiplication(2, 2);
+            var expected = 4;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestModulo()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.Modulo(3, 2);
+            var expected = 1;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestForLoop()
+        {
+            var targets = new BenchmarkTarget2();
+            targets.ForLoop(10);
+            Assert.True(true);
+        }
+
+        [Fact]
+        public void TestWhileLoop()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.WhileLoop(10);
+            var expected = 10;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestIf()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.If(true);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestLessThan()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = false;
+
+            actual = targets.LessThan(5, 10);
+
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestMoreThan()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.MoreThan(10, 5);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestLogicalAnd()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.LogicalAnd(0, 0);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Fact]
+        public void TestLogicalOr()
+        {
+            var targets = new BenchmarkTarget2();
+            var actual = targets.LogicalOr(0, 1);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    public class BenchmarkXUnit3
+    {
+        [Fact]
+        public void TestArray()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.ConstructArray();
+            int[] expected = { 1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7 };
+
+            Assert.Equal(expected, expected);
+        }
+
+        [Fact]
+        public void TestAddition()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Addition(5, 4);
+            var expected = 9;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestSubtraction()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Subtraction(5, 4);
+            var expected = 1;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDivision()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Division(2, 1);
+            var expected = 2;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestMultiplication()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Multiplication(2, 2);
+            var expected = 4;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestModulo()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.Modulo(3, 2);
+            var expected = 1;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestForLoop()
+        {
+            var targets = new BenchmarkTarget3();
+            targets.ForLoop(10);
+            Assert.True(true);
+        }
+
+        [Fact]
+        public void TestWhileLoop()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.WhileLoop(10);
+            var expected = 10;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestIf()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.If(true);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestLessThan()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = false;
+
+            actual = targets.LessThan(5, 10);
+
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestMoreThan()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.MoreThan(10, 5);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestLogicalAnd()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.LogicalAnd(0, 0);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Fact]
+        public void TestLogicalOr()
+        {
+            var targets = new BenchmarkTarget3();
+            var actual = targets.LogicalOr(0, 1);
+            var expected = true;
+            Assert.Equal(expected, actual);
+        }
+    }
 }

--- a/Benchmark/Faultify.Benchmark.XUnit/Faultify.Benchmark.XUnit.csproj
+++ b/Benchmark/Faultify.Benchmark.XUnit/Faultify.Benchmark.XUnit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Benchmark/Faultify.Benchmark/BenchmarkTarget.cs
+++ b/Benchmark/Faultify.Benchmark/BenchmarkTarget.cs
@@ -1,8 +1,266 @@
 ﻿using System;
+using System.Threading;
 
 namespace Faultify.Benchmark_0
 {
     public class BenchmarkTarget
+    {
+        // private const bool Constant = 1 < 2;
+        // public static bool TestStaticField = 1 < 2;
+        // public bool TestLocalField = 1 < 2;
+
+        public int[] ConstructArray()
+        {
+            return new[] {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
+        }
+
+        public int WhileLoop(int loops)
+        {
+            var i = 0;
+            while (i < loops) i++;
+
+            return i;
+        }
+
+        public void ForLoop(int loops)
+        {
+            for (var i = 0; i < loops; i++) Console.WriteLine();
+        }
+
+        public bool MoreThan(int lhs, int rhs)
+        {
+            if (lhs > rhs) return true;
+
+            return false;
+        }
+
+        public bool LessThan(int lhs, int rhs)
+        {
+            if (lhs < rhs) return true;
+
+            return false;
+        }
+
+        public bool LogicalAnd(int lhs, int rhs)
+        {
+            if (lhs == 0 && rhs == 0) return true;
+
+            return false;
+        }
+
+        public bool LogicalOr(int lhs, int rhs)
+        {
+            if (lhs == 0 || rhs == 0) return true;
+
+            return false;
+        }
+
+        public int Addition(int lhs, int rhs)
+        {
+            return lhs + rhs;
+        }
+
+        public int Subtraction(int lhs, int rhs)
+        {
+            return lhs - rhs;
+        }
+
+        public int Multiplication(int lhs, int rhs)
+        {
+            return lhs * rhs;
+        }
+
+        public int Division(int lhs, int rhs)
+        {
+            return lhs / rhs;
+        }
+
+        public int Modulo(int lhs, int rhs)
+        {
+            return lhs / rhs;
+        }
+
+        public bool If(bool condition)
+        {
+            if (condition) return true;
+
+            return false;
+        }
+
+    }
+
+    public class BenchmarkTarget1
+    {
+        // private const bool Constant = 1 < 2;
+        // public static bool TestStaticField = 1 < 2;
+        // public bool TestLocalField = 1 < 2;
+
+        public int[] ConstructArray()
+        {
+            return new[] {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
+        }
+
+        public int WhileLoop(int loops)
+        {
+            var i = 0;
+            while (i < loops) i++;
+
+            return i;
+        }
+
+        public void ForLoop(int loops)
+        {
+            for (var i = 0; i < loops; i++) Console.WriteLine();
+        }
+
+        public bool MoreThan(int lhs, int rhs)
+        {
+            if (lhs > rhs) return true;
+
+            return false;
+        }
+
+        public bool LessThan(int lhs, int rhs)
+        {
+            if (lhs < rhs) return true;
+
+            return false;
+        }
+
+        public bool LogicalAnd(int lhs, int rhs)
+        {
+            if (lhs == 0 && rhs == 0) return true;
+
+            return false;
+        }
+
+        public bool LogicalOr(int lhs, int rhs)
+        {
+            if (lhs == 0 || rhs == 0) return true;
+
+            return false;
+        }
+
+        public int Addition(int lhs, int rhs)
+        {
+            return lhs + rhs;
+        }
+
+        public int Subtraction(int lhs, int rhs)
+        {
+            return lhs - rhs;
+        }
+
+        public int Multiplication(int lhs, int rhs)
+        {
+            return lhs * rhs;
+        }
+
+        public int Division(int lhs, int rhs)
+        {
+            return lhs / rhs;
+        }
+
+        public int Modulo(int lhs, int rhs)
+        {
+            return lhs / rhs;
+        }
+
+        public bool If(bool condition)
+        {
+            if (condition) return true;
+
+            return false;
+        }
+    }
+
+    public class BenchmarkTarget2
+    {
+        // private const bool Constant = 1 < 2;
+        // public static bool TestStaticField = 1 < 2;
+        // public bool TestLocalField = 1 < 2;
+
+        public int[] ConstructArray()
+        {
+            return new[] {1, 2, 3, 6, 4, 2, 5, 3, 2, 6, 7};
+        }
+
+        public int WhileLoop(int loops)
+        {
+            var i = 0;
+            while (i < loops) i++;
+
+            return i;
+        }
+
+        public void ForLoop(int loops)
+        {
+        
+            for (var i = 0; i < loops; i++) Console.WriteLine();
+        }
+
+        public bool MoreThan(int lhs, int rhs)
+        {
+            if (lhs > rhs) return true;
+
+            return false;
+        }
+
+        public bool LessThan(int lhs, int rhs)
+        {
+            if (lhs < rhs) return true;
+
+            return false;
+        }
+
+        public bool LogicalAnd(int lhs, int rhs)
+        {
+            if (lhs == 0 && rhs == 0) return true;
+
+            return false;
+        }
+
+        public bool LogicalOr(int lhs, int rhs)
+        {
+            if (lhs == 0 || rhs == 0) return true;
+
+            return false;
+        }
+
+        public int Addition(int lhs, int rhs)
+        {
+            return lhs + rhs;
+        }
+
+        public int Subtraction(int lhs, int rhs)
+        {
+            return lhs - rhs;
+        }
+
+        public int Multiplication(int lhs, int rhs)
+        {
+            return lhs * rhs;
+        }
+
+        public int Division(int lhs, int rhs)
+        {
+            return lhs / rhs;
+        }
+
+        public int Modulo(int lhs, int rhs)
+        {
+            return lhs / rhs;
+        }
+
+        public bool If(bool condition)
+        {
+            if (condition) return true;
+
+            return false;
+        }
+    }
+
+    public class BenchmarkTarget3
     {
         // private const bool Constant = 1 < 2;
         // public static bool TestStaticField = 1 < 2;

--- a/Benchmark/Faultify.Benchmark/BenchmarkTarget.cs
+++ b/Benchmark/Faultify.Benchmark/BenchmarkTarget.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 
 namespace Faultify.Benchmark_0
 {
@@ -86,7 +85,6 @@ namespace Faultify.Benchmark_0
 
             return false;
         }
-
     }
 
     public class BenchmarkTarget1
@@ -195,7 +193,6 @@ namespace Faultify.Benchmark_0
 
         public void ForLoop(int loops)
         {
-        
             for (var i = 0; i < loops; i++) Console.WriteLine();
         }
 

--- a/Benchmark/README.md
+++ b/Benchmark/README.md
@@ -17,16 +17,15 @@ Score:     64.86%
 
 | Runners | Duration | Mutations per Second | 
 |---------|----------|----------------------|
-| 1       |  19526   |       0,62           | 
-| 2       |  16572   |       0,53           |
-| 3       |  16131   |       0,52           |
-| 4       |  16067   |       0,51           |
-| 5       |  20505   |       0,66           |
-| 6       |  25881   |       0,83           |
+| 1       |  19443   |       1,63           | 
+| 2       |  17650   |       1,82           |
+| 3       |  17703   |       1,82           |
+| 4       |  21046   |       1,48           |
+| 5       |  25285   |       1,24           |
+| 6       |  25566   |       1,24           |
 
 
 ## Run Faultify
-
 
 ```
 dotnet tool install --global faultify --version 0.1.0
@@ -37,17 +36,17 @@ faultify -t .\Faultify.Benchmark.NUnit\Faultify.Benchmark.NUnit.csproj  -f html 
 ```
 
 **Benchmark from Faultify.Benchmark.Runner**
-Mutations: 34
+Mutations: 29
 Score:     62%
 
 | Runners | Duration | Mutations per Second | 
 |---------|----------|----------------------|
-| 1       |  33028   |       0,97           | 
-| 2       |  20533   |       0,60           |
-| 3       |  13373   |       0,39           |
-| 4       |  13473   |       0,40           |
-| 5       |  12685   |       0,37           |
-| 6       |  13059   |       0,38           |
+| 1       |  22529   |       1,32           | 
+| 2       |  17510   |       1,71           |
+| 3       |  19905   |       1,53           |
+| 4       |  16187   |       1,81           |
+| 5       |  15547   |       1,93           |
+| 6       |  14885   |       2,07           |
 
 ## Results
 - Both stryker and faultify have the same ammount of mutations and the same score. 

--- a/Faultify.Cli/Faultify.Cli.csproj
+++ b/Faultify.Cli/Faultify.Cli.csproj
@@ -50,6 +50,8 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Faultify.Report\Faultify.Report.csproj" />
 		<ProjectReference Include="..\Faultify.TestRunner.Collector\Faultify.TestRunner.Collector.csproj" />
+		<ProjectReference Include="..\Faultify.TestRunner.Dotnet\Faultify.TestRunner.Dotnet.csproj" />
+		<ProjectReference Include="..\Faultify.TestRunner.NUnit\Faultify.TestRunner.NUnit.csproj" />
 		<ProjectReference Include="..\Faultify.TestRunner\Faultify.TestRunner.csproj" />
 	</ItemGroup>
 

--- a/Faultify.Cli/Program.cs
+++ b/Faultify.Cli/Program.cs
@@ -8,6 +8,8 @@ using Faultify.Report;
 using Faultify.Report.HTMLReporter;
 using Faultify.Report.PDFReporter;
 using Faultify.TestRunner;
+using Faultify.TestRunner.Dotnet;
+using Faultify.TestRunner.Logging;
 using Karambolo.Extensions.Logging.File;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -124,6 +126,7 @@ namespace Faultify.Cli
                     Console.ForegroundColor = ConsoleColor.White;
                 }
             };
+
             var progressTracker = new MutationSessionProgressTracker(progress, _loggerFactory);
 
             var testResult = await RunMutationTest(settings, progressTracker);
@@ -139,7 +142,7 @@ namespace Faultify.Cli
         {
             var mutationTestProject =
                 new MutationTestProject(settings.TestProjectPath, settings.MutationLevel, settings.Parallel,
-                    _loggerFactory);
+                    _loggerFactory, new DotnetTestHostRunnerFactory());
 
             return await mutationTestProject.Test(progressTracker, CancellationToken.None);
         }

--- a/Faultify.Cli/Properties/launchSettings.json
+++ b/Faultify.Cli/Properties/launchSettings.json
@@ -2,8 +2,7 @@
   "profiles": {
     "Faultify.Cli": {
       "commandName": "Project",
-      "commandLineArgs":
-        " -t  E:\\programming\\FaultifyNew\\Faultify\\Benchmark\\Faultify.Benchmark.XUnit\\Faultify.Benchmark.XUnit.csproj  -f html -p 4"
+      "commandLineArgs": " -t  E:\\programming\\FaultifyNew\\Faultify\\Benchmark\\Faultify.Benchmark.XUnit\\Faultify.Benchmark.XUnit.csproj  -f html -p 5"
     }
   }
 }

--- a/Faultify.Cli/Properties/launchSettings.json
+++ b/Faultify.Cli/Properties/launchSettings.json
@@ -2,7 +2,8 @@
   "profiles": {
     "Faultify.Cli": {
       "commandName": "Project",
-      "commandLineArgs": " -t  E:\\programming\\FaultifyNew\\Faultify\\Benchmark\\Faultify.Benchmark.XUnit\\Faultify.Benchmark.XUnit.csproj  -f html -p 5"
+      "commandLineArgs":
+        " -t  E:\\programming\\stryker-net\\src\\Stryker.Core\\Stryker.Core.UnitTest\\Stryker.Core.UnitTest.csproj  -f html -p 9"
     }
   }
 }

--- a/Faultify.Core/ProjectAnalyzing/ProjectReader.cs
+++ b/Faultify.Core/ProjectAnalyzing/ProjectReader.cs
@@ -17,7 +17,7 @@ namespace Faultify.Core.ProjectAnalyzing
                 var projectAnalyzer = analyzerManager.GetProject(path);
                 progress.Report($"Building {Path.GetFileName(path)}");
                 var analyzerResult =
-                    projectAnalyzer.Build(new EnvironmentOptions { DesignTime = false, Restore = true}).First();
+                    projectAnalyzer.Build(new EnvironmentOptions {DesignTime = false, Restore = true}).First();
 
                 return new ProjectInfo(analyzerResult);
             });

--- a/Faultify.Injection/CoverageRegistry.cs
+++ b/Faultify.Injection/CoverageRegistry.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using Faultify.TestRunner.Shared;
 
 namespace Faultify.Injection
@@ -46,7 +44,6 @@ namespace Faultify.Injection
         /// <param name="entityHandle"></param>
         public static void RegisterTargetCoverage(string assemblyName, int entityHandle)
         {
-            
             lock (RegisterMutex)
             {
                 try

--- a/Faultify.TestRunner.Dotnet/DotnetTestArgumentBuilder.cs
+++ b/Faultify.TestRunner.Dotnet/DotnetTestArgumentBuilder.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Faultify.TestRunner.TestProcess
+namespace Faultify.TestRunner.Dotnet
 {
     /// <summary>
     ///     Dotnet command argument builder.
@@ -37,7 +37,7 @@ namespace Faultify.TestRunner.TestProcess
 
         public DotnetTestArgumentBuilder WithTimeout(TimeSpan timeSpan)
         {
-            _arguments.Append($" --blame-hang-timeout {timeSpan.TotalMilliseconds}");
+            _arguments.Append($" --blame-hang-timeout {timeSpan.TotalMilliseconds}ms");
             return this;
         }
 

--- a/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
+++ b/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
@@ -25,14 +25,13 @@ namespace Faultify.TestRunner.Dotnet
     /// </summary>
     public class DotnetTestHostRunner : ITestHostRunner
     {
+        private static readonly bool DisableOutput = true;
+        private readonly ILogger _logger;
         private readonly string _testAdapterPath;
         private readonly DirectoryInfo _testDirectoryInfo;
 
         private readonly FileInfo _testFileInfo;
         private readonly TimeSpan _timeout;
-        private readonly ILogger _logger;
-
-        private static bool DisableOutput = true;
 
         public DotnetTestHostRunner(string testProjectAssemblyPath, TimeSpan timeout, ILogger logger)
         {
@@ -43,6 +42,74 @@ namespace Faultify.TestRunner.Dotnet
             _timeout = timeout;
             _logger = logger;
             _testAdapterPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        }
+
+        /// <summary>
+        ///     Runs the given tests and returns the results.
+        /// </summary>
+        /// <param name="progress"></param>
+        /// <param name="tests"></param>
+        /// <returns></returns>
+        public async Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress,
+            IEnumerable<string> tests)
+        {
+            var testResultOutputPath = Path.Combine(_testDirectoryInfo.FullName, TestRunnerConstants.TestsFileName);
+
+            var testResults = new List<TestResult>();
+            var remainingTests = new HashSet<string>(tests);
+
+            while (remainingTests.Any())
+                try
+                {
+                    var testProcessRunner = BuildTestProcessRunner(remainingTests);
+
+                    await testProcessRunner.RunAsync();
+                    _logger.LogDebug(testProcessRunner.Output.ToString());
+                    _logger.LogError(testProcessRunner.Error.ToString());
+
+                    var testResultsBinary = await File.ReadAllBytesAsync(testResultOutputPath,
+                        new CancellationTokenSource(timeout).Token);
+
+                    var deserializedTestResults = TestResults.Deserialize(testResultsBinary);
+
+                    remainingTests.RemoveWhere(x => deserializedTestResults.Tests.Any(y => y.Name == x));
+
+                    foreach (var testResult in deserializedTestResults.Tests) testResults.Add(testResult);
+                }
+                finally
+                {
+                    if (File.Exists(testResultOutputPath)) File.Delete(testResultOutputPath);
+                }
+
+            return new TestResults {Tests = testResults};
+        }
+
+        /// <summary>
+        ///     Run the code coverage process.
+        ///     This process finds out which tests cover which mutations.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<MutationCoverage> RunCodeCoverage(CancellationToken cancellationToken)
+        {
+            var coverageOutputPath = Path.Combine(_testDirectoryInfo.FullName, TestRunnerConstants.CoverageFileName);
+
+            try
+            {
+                var coverageProcessRunner = BuildCodeCoverageTestProcessRunner();
+                var process = await coverageProcessRunner.RunAsync();
+                _logger.LogDebug(coverageProcessRunner.Output.ToString());
+                _logger.LogError(coverageProcessRunner.Error.ToString());
+
+                if (process.ExitCode != 0) throw new ExitCodeException(process.ExitCode);
+
+                var coverageBinary = await File.ReadAllBytesAsync(coverageOutputPath, cancellationToken);
+                return MutationCoverage.Deserialize(coverageBinary);
+            }
+            finally
+            {
+                if (File.Exists(coverageOutputPath)) File.Delete(coverageOutputPath);
+            }
         }
 
         /// <summary>
@@ -68,7 +135,7 @@ namespace Faultify.TestRunner.Dotnet
                 CreateNoWindow = true,
                 WorkingDirectory = _testDirectoryInfo.FullName,
                 RedirectStandardOutput = DisableOutput,
-                RedirectStandardError = DisableOutput,
+                RedirectStandardError = DisableOutput
             };
 
             _logger.LogDebug($"Test process process arguments: {testArguments}");
@@ -103,75 +170,6 @@ namespace Faultify.TestRunner.Dotnet
             _logger.LogDebug($"Coverage test process arguments: {coverageArguments}");
 
             return new ProcessRunner(coverageProcessStartInfo);
-        }
-
-        /// <summary>
-        ///     Runs the given tests and returns the results.
-        /// </summary>
-        /// <param name="progress"></param>
-        /// <param name="tests"></param>
-        /// <returns></returns>
-        public async Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress,
-            IEnumerable<string> tests)
-        {
-            var testResultOutputPath = Path.Combine(_testDirectoryInfo.FullName, TestRunnerConstants.TestsFileName);
-
-            var testResults = new List<TestResult>();
-            var remainingTests = new HashSet<string>(tests);
-            
-            while (remainingTests.Any())
-            {
-                try
-                {
-                    var testProcessRunner = BuildTestProcessRunner(remainingTests);
-
-                    await testProcessRunner.RunAsync();
-                    _logger.LogDebug(testProcessRunner.Output.ToString());
-                    _logger.LogError(testProcessRunner.Error.ToString());
-
-                    var testResultsBinary = await File.ReadAllBytesAsync(testResultOutputPath, new CancellationTokenSource(timeout).Token);
-
-                    var deserializedTestResults = TestResults.Deserialize(testResultsBinary);
-
-                    remainingTests.RemoveWhere(x => deserializedTestResults.Tests.Any(y => y.Name == x));
-
-                    foreach (var testResult in deserializedTestResults.Tests) testResults.Add(testResult);
-                }
-                finally
-                {
-                    if (File.Exists(testResultOutputPath)) File.Delete(testResultOutputPath);
-                }
-            }
-
-            return new TestResults {Tests = testResults};
-        }
-
-        /// <summary>
-        ///     Run the code coverage process.
-        ///     This process finds out which tests cover which mutations.
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public async Task<MutationCoverage> RunCodeCoverage(CancellationToken cancellationToken)
-        {
-            var coverageOutputPath = Path.Combine(_testDirectoryInfo.FullName, TestRunnerConstants.CoverageFileName);
-
-            try
-            {
-                var coverageProcessRunner = BuildCodeCoverageTestProcessRunner();
-                var process = await coverageProcessRunner.RunAsync();
-                _logger.LogDebug(coverageProcessRunner.Output.ToString());
-                _logger.LogError(coverageProcessRunner.Error.ToString());
-
-                if (process.ExitCode != 0) throw new ExitCodeException(process.ExitCode);
-
-                var coverageBinary = await File.ReadAllBytesAsync(coverageOutputPath, cancellationToken);
-                return MutationCoverage.Deserialize(coverageBinary);
-            }
-            finally
-            {
-                if (File.Exists(coverageOutputPath)) File.Delete(coverageOutputPath);
-            }
         }
     }
 }

--- a/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
+++ b/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
@@ -137,10 +137,6 @@ namespace Faultify.TestRunner.Dotnet
 
                     foreach (var testResult in deserializedTestResults.Tests) testResults.Add(testResult);
                 }
-                catch (Exception ex)
-                {
-                    Console.WriteLine(ex);
-                }
                 finally
                 {
                     if (File.Exists(testResultOutputPath)) File.Delete(testResultOutputPath);

--- a/Faultify.TestRunner.Dotnet/Faultify.TestRunner.Dotnet.csproj
+++ b/Faultify.TestRunner.Dotnet/Faultify.TestRunner.Dotnet.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Faultify.TestRunner.Dotnet</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Faultify.TestRunner.Shared\Faultify.TestRunner.Shared.csproj" />
+    <ProjectReference Include="..\Faultify.TestRunner\Faultify.TestRunner.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Faultify.TestRunner.NUnit/Faultify.TestRunner.NUnit.csproj
+++ b/Faultify.TestRunner.NUnit/Faultify.TestRunner.NUnit.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	  <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.8.3" />
+    <PackageReference Include="NUnit.Engine" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Faultify.TestRunner\Faultify.TestRunner.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Faultify.TestRunner.NUnit/NUnitTestHostRunner.cs
+++ b/Faultify.TestRunner.NUnit/NUnitTestHostRunner.cs
@@ -85,10 +85,6 @@ namespace Faultify.TestRunner.NUnit
                     }
                 }
             }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
             finally
             {
                 runner.Dispose();

--- a/Faultify.TestRunner.NUnit/NUnitTestHostRunner.cs
+++ b/Faultify.TestRunner.NUnit/NUnitTestHostRunner.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Faultify.TestRunner.Shared;
+using Faultify.TestRunner.TestProcess;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NUnit.Engine.Runners;
+using Engine = NUnit.Engine;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+using TestResult = Faultify.TestRunner.Shared.TestResult;
+
+namespace Faultify.TestRunner.NUnit
+{
+    public class NUnitTestHostRunnerFactory : ITestHostRunFactory
+    {
+        public ITestHostRunner CreateTestRunner(string testProjectAssemblyPath, TimeSpan timeout, ILogger logger)
+        {
+            return new NUnitTestHostRunner(testProjectAssemblyPath, timeout, logger);
+        }
+    }
+
+    public class NUnitTestHostRunner : ITestHostRunner
+    {
+        private readonly string _testProjectAssemblyPath;
+        private readonly TimeSpan _timeout;
+        private readonly ILogger _logger;
+
+        public NUnitTestHostRunner(string testProjectAssemblyPath, TimeSpan timeout, ILogger logger)
+        {
+            _testProjectAssemblyPath = testProjectAssemblyPath;
+            _timeout = timeout;
+            _logger = logger;
+        }
+
+        private Engine.TestFilter GetTestFilter(IEnumerable<string> tests)
+        {
+            var testFilterBuilder = new Engine.TestFilterBuilder();
+            
+            foreach (var test in tests)
+            {
+                testFilterBuilder.AddTest(test);
+            }
+
+            return testFilterBuilder.GetFilter();
+        }
+
+        public Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress, IEnumerable<string> tests)
+        {
+            TestResults testResults = new TestResults();
+            
+            // Get an interface to the engine
+            using Engine.ITestEngine engine = Engine.TestEngineActivator.CreateInstance();
+            engine.WorkDirectory = new FileInfo(_testProjectAssemblyPath).DirectoryName;
+            
+            // Create a simple test package - one assembly, no special settings
+            Engine.TestPackage package = new Engine.TestPackage(_testProjectAssemblyPath);
+            package.AddSetting("DefaultTimeout", _timeout.Milliseconds);
+            package.AddSetting("StopOnError", true);
+            package.AddSetting("BaseDirectory", new FileInfo(_testProjectAssemblyPath).DirectoryName);
+            
+            // Get a runner for the test package
+            using var runner = engine.GetRunner(package);
+
+            try
+            {
+                XmlNode testSessionResult =
+                    runner.Run(null, GetTestFilter(tests)); 
+
+                var testCases = GetTestCases(testSessionResult);
+
+                foreach (XmlNode node in testCases)
+                {
+                    if (node.Attributes != null)
+                    {
+                        var testName = node.Attributes.GetNamedItem("fullname").Value;
+                        var testResult = node.Attributes.GetNamedItem("result").Value;
+                        
+                        testResults.Tests.Add(
+                            new TestResult() { Name = testName, Outcome = ParseTestOutcome(testResult) });
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            finally
+            {
+                runner.Dispose();
+                engine.Dispose();
+            }
+
+
+            return Task.FromResult(testResults);
+        }
+
+        public Task<MutationCoverage> RunCodeCoverage(CancellationToken cancellationToken)
+        {
+            // Get an interface to the engine
+            using Engine.ITestEngine engine = Engine.TestEngineActivator.CreateInstance();
+            engine.WorkDirectory = new FileInfo(_testProjectAssemblyPath).DirectoryName;
+
+            // Create a simple test package - one assembly, no special settings
+            Engine.TestPackage package = new Engine.TestPackage(_testProjectAssemblyPath);
+
+            package.AddSetting("DefaultTimeout", 1000);
+            package.AddSetting("StopOnError", true);
+            package.AddSetting("BaseDirectory", new FileInfo(_testProjectAssemblyPath).DirectoryName);
+
+            // Get a runner for the test package
+            using MasterTestRunner runner = (MasterTestRunner)engine.GetRunner(package);
+
+            try
+            {
+                // Run all the tests in the assembly
+                var testResult = runner.Run(null, Engine.TestFilter.Empty);
+                var testCases = GetTestCases(testResult);
+
+                HashSet<string> testNames = new HashSet<string>();
+
+                foreach (XmlNode node in testCases)
+                {
+                    if (node.Attributes != null) testNames.Add(node.Attributes.GetNamedItem("fullname").Value);
+                }
+
+                // Read coverage that was registered by: `Faultify.Injection.CoverageRegistry.RegisterTestCoverage()`.
+                var binary = File.ReadAllBytes(Path.Combine(
+                    Assembly.GetExecutingAssembly().Location,
+                    TestRunnerConstants.CoverageFileName));
+                var mutationCoverage = MutationCoverage.Deserialize(binary);
+
+                mutationCoverage.Coverage = mutationCoverage.Coverage
+                    .Where(pair => testNames.Contains(pair.Key))
+                    .ToDictionary(pair => pair.Key, pair => pair.Value);
+                
+                runner.StopRun(true);
+                runner.Unload();
+
+                return Task.FromResult(mutationCoverage);
+
+            }
+            catch (Exception e)
+            {
+                return Task.FromResult(new MutationCoverage()); 
+            }
+        }
+
+        private TestOutcome ParseTestOutcome(string testOutcome)
+        {
+            switch (testOutcome)
+            {
+                default: return TestOutcome.Failed;
+            }
+        }
+
+        private XmlNodeList GetTestCases(XmlNode xmlNode)
+        {
+            XmlDocument teamDoc = new XmlDocument();
+            teamDoc.AppendChild(teamDoc.ImportNode(xmlNode.LastChild, true));
+            var result = teamDoc.GetElementsByTagName("test-case");
+
+            return result;
+        }
+    }
+}

--- a/Faultify.TestRunner.NUnit/NUnitTestHostRunner.cs
+++ b/Faultify.TestRunner.NUnit/NUnitTestHostRunner.cs
@@ -7,10 +7,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Faultify.TestRunner.Shared;
-using Faultify.TestRunner.TestProcess;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NUnit.Engine;
 using NUnit.Engine.Runners;
-using Engine = NUnit.Engine;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 using TestResult = Faultify.TestRunner.Shared.TestResult;
 
@@ -26,9 +25,9 @@ namespace Faultify.TestRunner.NUnit
 
     public class NUnitTestHostRunner : ITestHostRunner
     {
+        private readonly ILogger _logger;
         private readonly string _testProjectAssemblyPath;
         private readonly TimeSpan _timeout;
-        private readonly ILogger _logger;
 
         public NUnitTestHostRunner(string testProjectAssemblyPath, TimeSpan timeout, ILogger logger)
         {
@@ -37,53 +36,39 @@ namespace Faultify.TestRunner.NUnit
             _logger = logger;
         }
 
-        private Engine.TestFilter GetTestFilter(IEnumerable<string> tests)
-        {
-            var testFilterBuilder = new Engine.TestFilterBuilder();
-            
-            foreach (var test in tests)
-            {
-                testFilterBuilder.AddTest(test);
-            }
-
-            return testFilterBuilder.GetFilter();
-        }
-
         public Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress, IEnumerable<string> tests)
         {
-            TestResults testResults = new TestResults();
-            
+            var testResults = new TestResults();
+
             // Get an interface to the engine
-            using Engine.ITestEngine engine = Engine.TestEngineActivator.CreateInstance();
+            using var engine = TestEngineActivator.CreateInstance();
             engine.WorkDirectory = new FileInfo(_testProjectAssemblyPath).DirectoryName;
-            
+
             // Create a simple test package - one assembly, no special settings
-            Engine.TestPackage package = new Engine.TestPackage(_testProjectAssemblyPath);
+            var package = new TestPackage(_testProjectAssemblyPath);
             package.AddSetting("DefaultTimeout", _timeout.Milliseconds);
             package.AddSetting("StopOnError", true);
             package.AddSetting("BaseDirectory", new FileInfo(_testProjectAssemblyPath).DirectoryName);
-            
+
             // Get a runner for the test package
             using var runner = engine.GetRunner(package);
 
             try
             {
-                XmlNode testSessionResult =
-                    runner.Run(null, GetTestFilter(tests)); 
+                var testSessionResult =
+                    runner.Run(null, GetTestFilter(tests));
 
                 var testCases = GetTestCases(testSessionResult);
 
                 foreach (XmlNode node in testCases)
-                {
                     if (node.Attributes != null)
                     {
                         var testName = node.Attributes.GetNamedItem("fullname").Value;
                         var testResult = node.Attributes.GetNamedItem("result").Value;
-                        
+
                         testResults.Tests.Add(
-                            new TestResult() { Name = testName, Outcome = ParseTestOutcome(testResult) });
+                            new TestResult {Name = testName, Outcome = ParseTestOutcome(testResult)});
                     }
-                }
             }
             finally
             {
@@ -98,31 +83,30 @@ namespace Faultify.TestRunner.NUnit
         public Task<MutationCoverage> RunCodeCoverage(CancellationToken cancellationToken)
         {
             // Get an interface to the engine
-            using Engine.ITestEngine engine = Engine.TestEngineActivator.CreateInstance();
+            using var engine = TestEngineActivator.CreateInstance();
             engine.WorkDirectory = new FileInfo(_testProjectAssemblyPath).DirectoryName;
 
             // Create a simple test package - one assembly, no special settings
-            Engine.TestPackage package = new Engine.TestPackage(_testProjectAssemblyPath);
+            var package = new TestPackage(_testProjectAssemblyPath);
 
             package.AddSetting("DefaultTimeout", 1000);
             package.AddSetting("StopOnError", true);
             package.AddSetting("BaseDirectory", new FileInfo(_testProjectAssemblyPath).DirectoryName);
 
             // Get a runner for the test package
-            using MasterTestRunner runner = (MasterTestRunner)engine.GetRunner(package);
+            using var runner = (MasterTestRunner) engine.GetRunner(package);
 
             try
             {
                 // Run all the tests in the assembly
-                var testResult = runner.Run(null, Engine.TestFilter.Empty);
+                var testResult = runner.Run(null, TestFilter.Empty);
                 var testCases = GetTestCases(testResult);
 
-                HashSet<string> testNames = new HashSet<string>();
+                var testNames = new HashSet<string>();
 
                 foreach (XmlNode node in testCases)
-                {
-                    if (node.Attributes != null) testNames.Add(node.Attributes.GetNamedItem("fullname").Value);
-                }
+                    if (node.Attributes != null)
+                        testNames.Add(node.Attributes.GetNamedItem("fullname").Value);
 
                 // Read coverage that was registered by: `Faultify.Injection.CoverageRegistry.RegisterTestCoverage()`.
                 var binary = File.ReadAllBytes(Path.Combine(
@@ -133,17 +117,25 @@ namespace Faultify.TestRunner.NUnit
                 mutationCoverage.Coverage = mutationCoverage.Coverage
                     .Where(pair => testNames.Contains(pair.Key))
                     .ToDictionary(pair => pair.Key, pair => pair.Value);
-                
+
                 runner.StopRun(true);
                 runner.Unload();
 
                 return Task.FromResult(mutationCoverage);
-
             }
             catch (Exception e)
             {
-                return Task.FromResult(new MutationCoverage()); 
+                return Task.FromResult(new MutationCoverage());
             }
+        }
+
+        private TestFilter GetTestFilter(IEnumerable<string> tests)
+        {
+            var testFilterBuilder = new TestFilterBuilder();
+
+            foreach (var test in tests) testFilterBuilder.AddTest(test);
+
+            return testFilterBuilder.GetFilter();
         }
 
         private TestOutcome ParseTestOutcome(string testOutcome)
@@ -156,7 +148,7 @@ namespace Faultify.TestRunner.NUnit
 
         private XmlNodeList GetTestCases(XmlNode xmlNode)
         {
-            XmlDocument teamDoc = new XmlDocument();
+            var teamDoc = new XmlDocument();
             teamDoc.AppendChild(teamDoc.ImportNode(xmlNode.LastChild, true));
             var result = teamDoc.GetElementsByTagName("test-case");
 

--- a/Faultify.TestRunner.Shared/MutationCoverage.cs
+++ b/Faultify.TestRunner.Shared/MutationCoverage.cs
@@ -3,10 +3,26 @@ using System.IO;
 
 namespace Faultify.TestRunner.Shared
 {
-    public class RegisteredCoverage
+    public class RegisteredCoverage 
     {
-        public string AssemblyName { get; set; }
-        public int EntityHandle { get; set; }
+        public RegisteredCoverage(string assemblyName, int entityHandle)
+        {
+            AssemblyName = assemblyName;
+            EntityHandle = entityHandle;
+        }
+
+        public string AssemblyName { get; }
+        public int EntityHandle { get; }
+
+        public override int GetHashCode()
+        {
+            return (AssemblyName + ":" + EntityHandle).GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RegisteredCoverage objCast && AssemblyName == objCast.AssemblyName && EntityHandle == objCast.EntityHandle;
+        }
     }
 
     // TODO: Uses custom format because Json requires external package.
@@ -54,8 +70,7 @@ namespace Faultify.TestRunner.Shared
                 {
                     var fullQualifiedName = binaryReader.ReadString();
                     var entityHandle = binaryReader.ReadInt32();
-                    entityHandles.Add(new RegisteredCoverage
-                        {EntityHandle = entityHandle, AssemblyName = fullQualifiedName});
+                    entityHandles.Add(new RegisteredCoverage(fullQualifiedName, entityHandle));
                 }
 
                 mutationCoverage.Coverage.Add(key, entityHandles);

--- a/Faultify.TestRunner.Shared/MutationCoverage.cs
+++ b/Faultify.TestRunner.Shared/MutationCoverage.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Faultify.TestRunner.Shared
 {
-    public class RegisteredCoverage 
+    public class RegisteredCoverage
     {
         public RegisteredCoverage(string assemblyName, int entityHandle)
         {
@@ -21,7 +21,8 @@ namespace Faultify.TestRunner.Shared
 
         public override bool Equals(object obj)
         {
-            return obj is RegisteredCoverage objCast && AssemblyName == objCast.AssemblyName && EntityHandle == objCast.EntityHandle;
+            return obj is RegisteredCoverage objCast && AssemblyName == objCast.AssemblyName &&
+                   EntityHandle == objCast.EntityHandle;
         }
     }
 

--- a/Faultify.TestRunner/Faultify.TestRunner.csproj
+++ b/Faultify.TestRunner/Faultify.TestRunner.csproj
@@ -15,6 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Faultify.Analyze\Faultify.Analyze.csproj" />
     <ProjectReference Include="..\Faultify.Core\Faultify.Core.csproj" />
     <ProjectReference Include="..\Faultify.Injection\Faultify.Injection.csproj" />

--- a/Faultify.TestRunner/ITestHostRunFactory.cs
+++ b/Faultify.TestRunner/ITestHostRunFactory.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 namespace Faultify.TestRunner
 {
     /// <summary>
-    /// Implement this factory for the creation of an <see cref="ITestHostRunner"/> instance.
+    ///     Implement this factory for the creation of an <see cref="ITestHostRunner" /> instance.
     /// </summary>
     public interface ITestHostRunFactory
     {

--- a/Faultify.TestRunner/ITestHostRunFactory.cs
+++ b/Faultify.TestRunner/ITestHostRunFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace Faultify.TestRunner
+{
+    /// <summary>
+    /// Implement this factory for the creation of an <see cref="ITestHostRunner"/> instance.
+    /// </summary>
+    public interface ITestHostRunFactory
+    {
+        public ITestHostRunner CreateTestRunner(string testProjectAssemblyPath, TimeSpan timeout, ILogger logger);
+    }
+}

--- a/Faultify.TestRunner/ITestHostRunner.cs
+++ b/Faultify.TestRunner/ITestHostRunner.cs
@@ -7,7 +7,7 @@ using Faultify.TestRunner.Shared;
 namespace Faultify.TestRunner
 {
     /// <summary>
-    /// Interface for running tests and code coverage on some test host.
+    ///     Interface for running tests and code coverage on some test host.
     /// </summary>
     public interface ITestHostRunner
     {

--- a/Faultify.TestRunner/ITestHostRunner.cs
+++ b/Faultify.TestRunner/ITestHostRunner.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Faultify.TestRunner.Shared;
+
+namespace Faultify.TestRunner
+{
+    /// <summary>
+    /// Interface for running tests and code coverage on some test host.
+    /// </summary>
+    public interface ITestHostRunner
+    {
+        /// <summary>
+        ///     Runs the given tests and returns the results.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <param name="progress"></param>
+        /// <param name="tests"></param>
+        /// <returns></returns>
+        Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress,
+            IEnumerable<string> tests);
+
+        /// <summary>
+        ///     Run the code coverage process.
+        ///     This process finds out which tests cover which mutations.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<MutationCoverage> RunCodeCoverage(CancellationToken cancellationToken);
+    }
+}

--- a/Faultify.TestRunner/Logging/LogMessageType.cs
+++ b/Faultify.TestRunner/Logging/LogMessageType.cs
@@ -4,7 +4,7 @@
     {
         CodeCoverage,
         TestRunUpdate,
-        TestSessionStart, 
+        TestSessionStart,
         TestSessionEnd,
         Error,
         Other

--- a/Faultify.TestRunner/Logging/LogMessageType.cs
+++ b/Faultify.TestRunner/Logging/LogMessageType.cs
@@ -1,0 +1,12 @@
+﻿namespace Faultify.TestRunner.Logging
+{
+    public enum LogMessageType
+    {
+        CodeCoverage,
+        TestRunUpdate,
+        TestSessionStart, 
+        TestSessionEnd,
+        Error,
+        Other
+    }
+}

--- a/Faultify.TestRunner/Logging/MutationRunProgress.cs
+++ b/Faultify.TestRunner/Logging/MutationRunProgress.cs
@@ -1,4 +1,4 @@
-﻿namespace Faultify.TestRunner
+﻿namespace Faultify.TestRunner.Logging
 {
     public struct MutationRunProgress
     {

--- a/Faultify.TestRunner/Logging/MutationSessionProgressTracker.cs
+++ b/Faultify.TestRunner/Logging/MutationSessionProgressTracker.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
+using Microsoft.Extensions.Logging;
 
-namespace Faultify.TestRunner
+namespace Faultify.TestRunner.Logging
 {
     /// <summary>
     ///     Helper class for tracking the mutation test logs and percentual progress.
@@ -86,7 +86,7 @@ namespace Faultify.TestRunner
             _currentPercentage = 85;
             Log($"Finished Mutation Session:\n" +
                 $"| Test Rounds: {completedTestRounds}\n" +
-                $"| Mutation per Second: {((mutationCount / elapsed.Milliseconds) * 1000):0.0}mps\n" +
+                $"| Mutation per Second: {((mutationCount / elapsed.Seconds)):0.0}mps\n" +
                 $"| Duration: {elapsed:hh\\:mm\\:ss}\n" +
                 $"| Score: {score:0.0}%"+
                 $"\n", LogMessageType.TestSessionEnd
@@ -125,15 +125,5 @@ namespace Faultify.TestRunner
         {
             return (value - fromSource) / (toSource - fromSource) * (toTarget - fromTarget) + fromTarget;
         }
-    }
-
-    public enum LogMessageType
-    {
-        CodeCoverage,
-        TestRunUpdate,
-        TestSessionStart, 
-        TestSessionEnd,
-        Error,
-        Other
     }
 }

--- a/Faultify.TestRunner/Logging/MutationSessionProgressTracker.cs
+++ b/Faultify.TestRunner/Logging/MutationSessionProgressTracker.cs
@@ -8,8 +8,8 @@ namespace Faultify.TestRunner.Logging
     /// </summary>
     public class MutationSessionProgressTracker : IProgress<string>
     {
-        private readonly IProgress<MutationRunProgress> _progress;
         private readonly ILogger _logger;
+        private readonly IProgress<MutationRunProgress> _progress;
 
         private int _currentPercentage;
 
@@ -48,7 +48,7 @@ namespace Faultify.TestRunner.Logging
             _currentPercentage = 15;
             Log("End duplication test project...");
         }
-        
+
         public void LogBeginCoverage()
         {
             _currentPercentage = 17;
@@ -63,50 +63,50 @@ namespace Faultify.TestRunner.Logging
         {
             _currentPercentage = 20;
 
-            Log($"Start Mutation Test Session:\n" +
+            Log("Start Mutation Test Session:\n" +
                 $"| Test Rounds: {totalTestRounds}\n" +
                 $"| Mutations Found: {mutationCount}\n" +
                 $"| Worst Case Time: {totalTestRounds * testRunTime.Seconds}s"
                 , LogMessageType.TestSessionStart
             );
         }
-        
+
         public void LogTestRunUpdate(int index, int max, int failedRuns)
         {
             _currentPercentage = (int) Map(index, 0f, max, 0f, 100f);
-            Log($"Test Run Progress:\n" +
+            Log("Test Run Progress:\n" +
                 $"| Test Runs: {max - index}\n" +
                 $"| Completed: {index}\n" +
                 $"| Failed: {failedRuns}" +
-                $"", LogMessageType.TestRunUpdate);
+                "", LogMessageType.TestRunUpdate);
         }
 
         public void LogEndTestSession(TimeSpan elapsed, int completedTestRounds, int mutationCount, float score)
         {
             _currentPercentage = 85;
-            Log($"Finished Mutation Session:\n" +
+            Log("Finished Mutation Session:\n" +
                 $"| Test Rounds: {completedTestRounds}\n" +
-                $"| Mutation per Second: {((mutationCount / elapsed.Seconds)):0.0}mps\n" +
+                $"| Mutation per Second: {mutationCount / elapsed.Seconds:0.0}mps\n" +
                 $"| Duration: {elapsed:hh\\:mm\\:ss}\n" +
-                $"| Score: {score:0.0}%"+
-                $"\n", LogMessageType.TestSessionEnd
+                $"| Score: {score:0.0}%" +
+                "\n", LogMessageType.TestSessionEnd
             );
         }
 
         public void LogBeginReportBuilding(string reportType, string reportPath)
         {
             _currentPercentage = 98;
-            Log($"Generate Report:\n" +
-                $"| Report Path: { reportPath} \t\t \n" +
-                $"| Report Type: { reportType} \t\t \n"
+            Log("Generate Report:\n" +
+                $"| Report Path: {reportPath} \t\t \n" +
+                $"| Report Type: {reportType} \t\t \n"
             );
         }
 
         public void LogEndFaultify(string processLog)
         {
             _currentPercentage = 100;
-            Log($"Faultify is Done:\n" +
-                $"| Logs: { processLog } \t\t"
+            Log("Faultify is Done:\n" +
+                $"| Logs: {processLog} \t\t"
             );
         }
 

--- a/Faultify.TestRunner/MutationTestProject.cs
+++ b/Faultify.TestRunner/MutationTestProject.cs
@@ -271,11 +271,6 @@ namespace Faultify.TestRunner
                 }
             }
 
-            // foreach (var run in mutationTestRuns)
-            // {
-            //     RunTestRun(run).Wait();
-            // }
-
             IEnumerable<Task> tasks = from testRun in mutationTestRuns select RunTestRun(testRun);
             
             Task.WaitAll(tasks.ToArray());

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplication.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplication.cs
@@ -93,7 +93,7 @@ namespace Faultify.TestRunner.ProjectDuplication
 
                     foreach (var method in type.Methods)
                     {
-                        if (!toMutateMethods.Contains(method.Name))
+                        if (!toMutateMethods.Contains(method.AssemblyQualifiedName))
                             continue;
 
                         var methodMutationId = 0;
@@ -102,7 +102,7 @@ namespace Faultify.TestRunner.ProjectDuplication
                         foreach (var mutation in group)
                         {
                             var mutationIdentifier = mutationIdentifiers.FirstOrDefault(x =>
-                                x.MutationId == methodMutationId && method.Name == x.MemberName);
+                                x.MutationId == methodMutationId && method.AssemblyQualifiedName == x.MemberName);
 
                             if (mutationIdentifier.MemberName != null)
                                 foundMutations.Add(new MutationVariant

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplication.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplication.cs
@@ -115,8 +115,8 @@ namespace Faultify.TestRunner.ProjectDuplication
                                     Mutation = mutation,
                                     MutationAnalyzerInfo = new MutationAnalyzerInfo
                                     {
-                                        AnalyzerDescription = @group.AnalyzerDescription,
-                                        AnalyzerName = @group.AnalyzerName
+                                        AnalyzerDescription = group.AnalyzerDescription,
+                                        AnalyzerName = group.AnalyzerName
                                     },
                                     MutationIdentifier = mutationIdentifier
                                 });

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicationPool.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicationPool.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicationPool.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicationPool.cs
@@ -47,9 +47,9 @@ namespace Faultify.TestRunner.ProjectDuplication
                 var freeProject = GetFreeProject();
 
                 if (freeProject != null) return freeProject;
-                
+
                 _signalEvent.WaitOne();
-                
+
                 freeProject = GetFreeProject();
 
                 if (freeProject != null)

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicator.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicator.cs
@@ -65,7 +65,7 @@ namespace Faultify.TestRunner.ProjectDuplication
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e);
+                    throw e;
                 }
             }
 

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicator.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicator.cs
@@ -24,11 +24,10 @@ namespace Faultify.TestRunner.ProjectDuplication
             // Remove useless folders.
             foreach (var directory in dirInfo.GetDirectories("*"))
             {
-                var match = Regex.Match(directory.Name, "(^cs$|^pl$|^rt$|^de$|^en$|^es$|^fr$|^it$|^ja$|^ko$|^ru$|^zh-Hans$|^zh-Hant$|^test-duplication-\\d$)");
+                var match = Regex.Match(directory.Name,
+                    "(^cs$|^pl$|^rt$|^de$|^en$|^es$|^fr$|^it$|^ja$|^ko$|^ru$|^zh-Hans$|^zh-Hant$|^test-duplication-\\d$)");
 
-                if (match.Captures.Count != 0) {
-                    Directory.Delete(directory.FullName, true);
-                }
+                if (match.Captures.Count != 0) Directory.Delete(directory.FullName, true);
             }
 
             var testProjectDuplications = new List<TestProjectDuplication>();
@@ -39,7 +38,6 @@ namespace Faultify.TestRunner.ProjectDuplication
 
 
             foreach (var file in allFiles)
-            {
                 try
                 {
                     var mFile = new FileInfo(file);
@@ -54,20 +52,15 @@ namespace Faultify.TestRunner.ProjectDuplication
                         var path = mFile.FullName.Replace(newDirInfo.Parent.FullName, "");
                         var newPath = new FileInfo(Path.Combine(newDirInfo.FullName, path.Trim('\\')));
 
-                        if (!Directory.Exists(newPath.DirectoryName))
-                        {
-                            Directory.CreateDirectory(newPath.DirectoryName);
-                        }
+                        if (!Directory.Exists(newPath.DirectoryName)) Directory.CreateDirectory(newPath.DirectoryName);
 
                         mFile.MoveTo(newPath.FullName, true);
                     }
-                    
                 }
                 catch (Exception e)
                 {
                     throw e;
                 }
-            }
 
             var initialCopies = testProject.ProjectReferences
                 .Select(x => new FileDuplication(newDirInfo.FullName, Path.GetFileNameWithoutExtension(x) + ".dll"));
@@ -78,7 +71,7 @@ namespace Faultify.TestRunner.ProjectDuplication
             ));
 
             // Copy the initial copy N times.
-            Parallel.ForEach(Enumerable.Range(1, count), (i) =>
+            Parallel.ForEach(Enumerable.Range(1, count), i =>
             {
                 var duplicatedDirectoryPath = Path.Combine(_testDirectory, $"test-duplication-{i}");
                 CopyFilesRecursively(newDirInfo, Directory.CreateDirectory(duplicatedDirectoryPath));
@@ -94,7 +87,7 @@ namespace Faultify.TestRunner.ProjectDuplication
                     )
                 );
             });
-            
+
             return testProjectDuplications;
         }
 

--- a/Faultify.TestRunner/TestProcess/ProcessRunner.cs
+++ b/Faultify.TestRunner/TestProcess/ProcessRunner.cs
@@ -1,9 +1,6 @@
 ﻿using System.Diagnostics;
-using System.IO;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Faultify.TestRunner.Shared;
 
 namespace Faultify.TestRunner.TestProcess
 {
@@ -13,7 +10,15 @@ namespace Faultify.TestRunner.TestProcess
     public class ProcessRunner
     {
         private readonly ProcessStartInfo _processStartInfo;
+
+        /// <summary>
+        /// The output message of this process.
+        /// </summary>
         public StringBuilder Output;
+        
+        /// <summary>
+        /// The error message of this process. 
+        /// </summary>
         public StringBuilder Error;
 
         public ProcessRunner(ProcessStartInfo processStartInfo)
@@ -21,15 +26,21 @@ namespace Faultify.TestRunner.TestProcess
             _processStartInfo = processStartInfo;
         }
 
-        public async Task<Process> RunAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// Runs the process asynchronously.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Process> RunAsync()
         {
             var process = new Process();
-
-            var cancellationTokenRegistration = cancellationToken.Register(() => { process.Kill(true); });
-
+            
             var taskCompletionSource = new TaskCompletionSource<object>();
             process.EnableRaisingEvents = true;
-            process.Exited += (o, e) => { taskCompletionSource.TrySetResult(null); };
+            process.Exited += (o, e) =>
+            {
+                taskCompletionSource.TrySetResult(null);
+            };
+
             process.StartInfo = _processStartInfo;
 
             Output = new StringBuilder();
@@ -50,7 +61,6 @@ namespace Faultify.TestRunner.TestProcess
             process.BeginErrorReadLine();
 
             await taskCompletionSource.Task;
-            await cancellationTokenRegistration.DisposeAsync();
 
             process.WaitForExit();
 

--- a/Faultify.TestRunner/TestProcess/ProcessRunner.cs
+++ b/Faultify.TestRunner/TestProcess/ProcessRunner.cs
@@ -12,14 +12,14 @@ namespace Faultify.TestRunner.TestProcess
         private readonly ProcessStartInfo _processStartInfo;
 
         /// <summary>
-        /// The output message of this process.
-        /// </summary>
-        public StringBuilder Output;
-        
-        /// <summary>
-        /// The error message of this process. 
+        ///     The error message of this process.
         /// </summary>
         public StringBuilder Error;
+
+        /// <summary>
+        ///     The output message of this process.
+        /// </summary>
+        public StringBuilder Output;
 
         public ProcessRunner(ProcessStartInfo processStartInfo)
         {
@@ -27,34 +27,25 @@ namespace Faultify.TestRunner.TestProcess
         }
 
         /// <summary>
-        /// Runs the process asynchronously.
+        ///     Runs the process asynchronously.
         /// </summary>
         /// <returns></returns>
         public async Task<Process> RunAsync()
         {
             var process = new Process();
-            
+
             var taskCompletionSource = new TaskCompletionSource<object>();
             process.EnableRaisingEvents = true;
-            process.Exited += (o, e) =>
-            {
-                taskCompletionSource.TrySetResult(null);
-            };
+            process.Exited += (o, e) => { taskCompletionSource.TrySetResult(null); };
 
             process.StartInfo = _processStartInfo;
 
             Output = new StringBuilder();
             Error = new StringBuilder();
 
-            process.OutputDataReceived += (sender, e) =>
-            {
-                Output.AppendLine(e.Data);
-            };
-            process.ErrorDataReceived += (sender, e) =>
-            {
-                Error.AppendLine(e.Data);
-            };
-            
+            process.OutputDataReceived += (sender, e) => { Output.AppendLine(e.Data); };
+            process.ErrorDataReceived += (sender, e) => { Error.AppendLine(e.Data); };
+
             process.Start();
 
             process.BeginOutputReadLine();

--- a/Faultify.TestRunner/TestProjectReportModelBuilder.cs
+++ b/Faultify.TestRunner/TestProjectReportModelBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Faultify.Report;
 using Faultify.TestRunner.Shared;
 using Faultify.TestRunner.TestRun;
@@ -12,21 +11,19 @@ namespace Faultify.TestRunner
 {
     public class TestProjectReportModelBuilder
     {
+        private static readonly object Mutext = new object();
         private readonly TestProjectReportModel _testProjectReportModel;
 
         public TestProjectReportModelBuilder(string testProjectName)
         {
             _testProjectReportModel = new TestProjectReportModel(testProjectName, TimeSpan.MaxValue);
         }
-        
-        static readonly object Mutext = new object();
 
         public void AddTestResult(TestResults testResults, IEnumerable<MutationVariant> mutations,
             TimeSpan testRunDuration)
         {
             lock (Mutext)
             {
-
                 foreach (var testResult in testResults.Tests)
                 {
                     var mutation =
@@ -40,7 +37,6 @@ namespace Faultify.TestRunner
                     if (!_testProjectReportModel.Mutations.Any(x =>
                         x.MutationId == mutation.MutationIdentifier.MutationId &&
                         mutation.MutationIdentifier.MemberName == x.MemberName))
-                    {
                         _testProjectReportModel.Mutations.Add(new MutationVariantReportModel(
                             mutation.Mutation.ToString(), "",
                             new MutationAnalyzerReportModel(mutation.MutationAnalyzerInfo.AnalyzerName,
@@ -52,7 +48,6 @@ namespace Faultify.TestRunner
                             mutation.MutationIdentifier.MutationId,
                             mutation.MutationIdentifier.MemberName
                         ));
-                    }
                 }
             }
         }

--- a/Faultify.TestRunner/TestRun/DefaultMutationTestRun.cs
+++ b/Faultify.TestRunner/TestRun/DefaultMutationTestRun.cs
@@ -21,7 +21,7 @@ namespace Faultify.TestRunner.TestRun
 
         public int RunId { get; set; }
         public int MutationCount => MutationIdentifiers.Count;
-        
+
         public async Task<IEnumerable<TestRunResult>> RunMutationTestAsync(TimeSpan timeout,
             MutationSessionProgressTracker sessionProgressTracker, ITestHostRunFactory testHostRunnerFactory,
             TestProjectDuplication testProject, ILogger logger)
@@ -34,8 +34,8 @@ namespace Faultify.TestRunner.TestRun
             var testRunner = testHostRunnerFactory.CreateTestRunner(testProject.TestProjectFile.FullFilePath(),
                 timeout, logger);
 
-            var testResults = 
-                await testRunner.RunTests(timeout,  sessionProgressTracker, runningTests);
+            var testResults =
+                await testRunner.RunTests(timeout, sessionProgressTracker, runningTests);
 
             ResetMutations(testProject);
 

--- a/Faultify.TestRunner/TestRun/DefaultMutationTestRunGenerator.cs
+++ b/Faultify.TestRunner/TestRun/DefaultMutationTestRunGenerator.cs
@@ -83,7 +83,7 @@ namespace Faultify.TestRunner.TestRun
                     {
                         foreach (var mutation in group)
                         {
-                            allMutations.Add(new MutationVariantIdentifier(registeredMutation.Value, method.Name,
+                            allMutations.Add(new MutationVariantIdentifier(registeredMutation.Value, method.AssemblyQualifiedName,
                                 methodMutationId, mutationGroupId));
 
                             methodMutationId++;

--- a/Faultify.TestRunner/TestRun/DefaultMutationTestRunGenerator.cs
+++ b/Faultify.TestRunner/TestRun/DefaultMutationTestRunGenerator.cs
@@ -83,7 +83,8 @@ namespace Faultify.TestRunner.TestRun
                     {
                         foreach (var mutation in group)
                         {
-                            allMutations.Add(new MutationVariantIdentifier(registeredMutation.Value, method.AssemblyQualifiedName,
+                            allMutations.Add(new MutationVariantIdentifier(registeredMutation.Value,
+                                method.AssemblyQualifiedName,
                                 methodMutationId, mutationGroupId));
 
                             methodMutationId++;

--- a/Faultify.TestRunner/TestRun/IMutationTestRun.cs
+++ b/Faultify.TestRunner/TestRun/IMutationTestRun.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Threading;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Faultify.TestRunner.Logging;
 using Faultify.TestRunner.ProjectDuplication;
-using Faultify.TestRunner.TestProcess;
+using Microsoft.Extensions.Logging;
 
 namespace Faultify.TestRunner.TestRun
 {
@@ -13,19 +14,19 @@ namespace Faultify.TestRunner.TestRun
     {
         public int RunId { get; set; }
 
-        public int MutationCount { get;}
+        public int MutationCount { get; }
 
         /// <summary>
         ///     Runs the mutation test and returns the test run results.
         /// </summary>
-        /// <param name="token"></param>
+        /// <param name="timeout"></param>
         /// <param name="sessionProgressTracker"></param>
-        /// <param name="dotnetTestRunner"></param>
+        /// <param name="testHostRunnerFactory"></param>
         /// <param name="projectDuplication"></param>
         /// <returns></returns>
-        Task<IEnumerable<TestRunResult>> RunMutationTestAsync(CancellationToken token,
-            MutationSessionProgressTracker sessionProgressTracker, DotnetTestRunner dotnetTestRunner,
-            TestProjectDuplication projectDuplication);
+        Task<IEnumerable<TestRunResult>> RunMutationTestAsync(TimeSpan timeout,
+            MutationSessionProgressTracker sessionProgressTracker, ITestHostRunFactory testHostRunnerFactory,
+            TestProjectDuplication projectDuplication, ILogger logger);
 
 
         /// <summary>

--- a/Faultify.sln
+++ b/Faultify.sln
@@ -37,6 +37,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Faultify.Benchmark", "Bench
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Faultify.Benchmark.Runner", "Benchmark\Faultify.Benchmark.Runner\Faultify.Benchmark.Runner.csproj", "{20E165F7-4AB1-49C9-BF33-2912EC186B44}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Faultify.TestRunner.NUnit", "Faultify.TestRunner.NUnit\Faultify.TestRunner.NUnit.csproj", "{208C8720-EAAE-461A-B10B-D6FB45FC98AB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Faultify.TestRunner.Dotnet", "Faultify.TestRunner.Dotnet\Faultify.TestRunner.Dotnet.csproj", "{AAC37C7D-01A9-4A8B-84DB-D6DF9533B094}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,6 +99,14 @@ Global
 		{20E165F7-4AB1-49C9-BF33-2912EC186B44}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20E165F7-4AB1-49C9-BF33-2912EC186B44}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20E165F7-4AB1-49C9-BF33-2912EC186B44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{208C8720-EAAE-461A-B10B-D6FB45FC98AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{208C8720-EAAE-461A-B10B-D6FB45FC98AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{208C8720-EAAE-461A-B10B-D6FB45FC98AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{208C8720-EAAE-461A-B10B-D6FB45FC98AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAC37C7D-01A9-4A8B-84DB-D6DF9533B094}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAC37C7D-01A9-4A8B-84DB-D6DF9533B094}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAC37C7D-01A9-4A8B-84DB-D6DF9533B094}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAC37C7D-01A9-4A8B-84DB-D6DF9533B094}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -108,6 +120,8 @@ Global
 		{E614C588-556A-4868-BBB3-96D52AC2A848} = {0EAACBAA-2F1D-4E80-82B0-CE32404832AD}
 		{147FA95E-46BF-4FF2-981A-ED1443B500FD} = {0EAACBAA-2F1D-4E80-82B0-CE32404832AD}
 		{20E165F7-4AB1-49C9-BF33-2912EC186B44} = {0EAACBAA-2F1D-4E80-82B0-CE32404832AD}
+		{208C8720-EAAE-461A-B10B-D6FB45FC98AB} = {3ECCAFB9-AFBD-4E9D-AB4F-42069EF87863}
+		{AAC37C7D-01A9-4A8B-84DB-D6DF9533B094} = {3ECCAFB9-AFBD-4E9D-AB4F-42069EF87863}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C3ABD84B-C788-4014-987E-3790097964ED}

--- a/Faultify.sln.DotSettings.user
+++ b/Faultify.sln.DotSettings.user
@@ -1,15 +1,29 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=04f8c78c_002Db102_002D4bae_002D8bdf_002D1a213fe4c644/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="OpenWriteStream" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;NUnit3x::CC69D0AF-8ADA-48AA-ACF5-D44BB124016A::.NETCoreApp,Version=v3.1::Faultify.Benchmark.NUnit.BenchmarkNUnit&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
+  &lt;Or&gt;&#xD;
+    &lt;And&gt;&#xD;
+      &lt;Or&gt;&#xD;
+        &lt;TestAncestor&gt;&#xD;
+          &lt;TestId&gt;NUnit3x::CC69D0AF-8ADA-48AA-ACF5-D44BB124016A::.NETCoreApp,Version=v3.1::Faultify.Benchmark.NUnit.BenchmarkNUnit&lt;/TestId&gt;&#xD;
+        &lt;/TestAncestor&gt;&#xD;
+        &lt;Project Location="E:\programming\FaultifyNew\Faultify\Benchmark\Faultify.Benchmark.XUnit" Presentation="&amp;lt;Benchmark&amp;gt;\&amp;lt;Faultify.Benchmark.XUnit&amp;gt;" /&gt;&#xD;
+      &lt;/Or&gt;&#xD;
+      &lt;Not&gt;&#xD;
+        &lt;TestAncestor&gt;&#xD;
+          &lt;TestId&gt;xUnit::E614C588-556A-4868-BBB3-96D52AC2A848::.NETCoreApp,Version=v3.1::Faultify.Benchmark.XUnit.BenchmarkXUnit.TestArray&lt;/TestId&gt;&#xD;
+        &lt;/TestAncestor&gt;&#xD;
+      &lt;/Not&gt;&#xD;
+    &lt;/And&gt;&#xD;
+    &lt;Project Location="E:\programming\FaultifyNew\Faultify\Benchmark\Faultify.Benchmark.XUnit" Presentation="&amp;lt;Benchmark&amp;gt;\&amp;lt;Faultify.Benchmark.XUnit&amp;gt;" /&gt;&#xD;
+    &lt;Project Location="E:\programming\FaultifyNew\Faultify\Benchmark\Faultify.Benchmark.NUnit" Presentation="&amp;lt;Benchmark&amp;gt;\&amp;lt;Faultify.Benchmark.NUnit&amp;gt;" /&gt;&#xD;
+  &lt;/Or&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=32a3a768_002Db6da_002D4330_002D8cc9_002D95f92b9fb31e/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Arithmetic_PostMutation_MinToPlus" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=32a3a768_002Db6da_002D4330_002D8cc9_002D95f92b9fb31e/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Arithmetic_PostMutation_MinToPlus" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
     &lt;TestId&gt;NUnit3x::CBF4B950-7AA2-47A1-852E-A31A175E1114::.NETCoreApp,Version=v3.1::Faultify.Benchmark.Nunit.BenchmarkNUnit&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=cb050727_002Dc0ea_002D48a4_002D8178_002D166995f6c472/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="HasTwoMethodMutations_False" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=cb050727_002Dc0ea_002D48a4_002D8178_002D166995f6c472/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="HasTwoMethodMutations_False" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Or&gt;&#xD;
     &lt;Project Location="E:\programming\FaultifyNew\Faultify\Faultify.Tests" Presentation="&amp;lt;Faultify.Tests&amp;gt;" /&gt;&#xD;
     &lt;Project Location="E:\programming\FaultifyNew\Faultify\Benchmark\Faultify.Benchmark.NUnit" Presentation="&amp;lt;Benchmark&amp;gt;\&amp;lt;Faultify.Benchmark.NUnit&amp;gt;" /&gt;&#xD;

--- a/docs/.idea/workspace.xml
+++ b/docs/.idea/workspace.xml
@@ -28,7 +28,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="ebaf08ce-0659-4ecc-91a4-5c67630faa38" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/../Benchmark/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/../Benchmark/README.md" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/../Faultify.sln.DotSettings.user" beforeDir="false" afterPath="$PROJECT_DIR$/../Faultify.sln.DotSettings.user" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -72,7 +74,8 @@
       <updated>1611175589488</updated>
       <workItem from="1611175590779" duration="2667000" />
       <workItem from="1611219416308" duration="7126000" />
-      <workItem from="1612172800986" duration="652000" />
+      <workItem from="1612172800986" duration="653000" />
+      <workItem from="1612271129120" duration="167000" />
     </task>
     <servers />
   </component>


### PR DESCRIPTION
* Create Runner Abstraction
* Start implementation NUnit
* Fix bug dictionary key register coverage.
* Add more unit tests and classes for test purposes.
* Run faultify and striker benchmark in one run.
* Update benchmark results
* Change seconds per mutations to mutations per second
* Add 'ms' after dotnet blame timeout. 
* Fix benchmark paths.
* Make dotnet test runner loop continue after exception.

_(ps. sorry for big PR)_