### PR TITLE
Disable XUnit parallel feature for codecoverage run. 

### DIFF
--- a/Benchmark/Faultify.Benchmark.MSTest/BenchmarkMSTest.cs
+++ b/Benchmark/Faultify.Benchmark.MSTest/BenchmarkMSTest.cs
@@ -1,10 +1,9 @@
-using Faultify.Benchmark_0;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Faultify.Benchmark.MSTest
 {
     [TestClass]
-    public class BenchmarkXUnit
+    public class BenchmarkMSTest
     {
         [TestMethod]
         public void TestArray()
@@ -129,7 +128,7 @@ namespace Faultify.Benchmark.MSTest
     }
 
     [TestClass]
-    public class BenchmarkXUnit1
+    public class BenchmarkMSTest1
     {
         [TestMethod]
         public void TestArray()
@@ -254,7 +253,7 @@ namespace Faultify.Benchmark.MSTest
     }
 
     [TestClass]
-    public class BenchmarkXUnit2
+    public class BenchmarkMSTest2
     {
         [TestMethod]
         public void TestArray()
@@ -379,7 +378,7 @@ namespace Faultify.Benchmark.MSTest
     }
 
     [TestClass]
-    public class BenchmarkXUnit3
+    public class BenchmarkMSTest3
     {
         [TestMethod]
         public void TestArray()

--- a/Benchmark/Faultify.Benchmark.NUnit/BenchmarkNUnit.cs
+++ b/Benchmark/Faultify.Benchmark.NUnit/BenchmarkNUnit.cs
@@ -1,9 +1,8 @@
-using Faultify.Benchmark_0;
 using NUnit.Framework;
 
 namespace Faultify.Benchmark.NUnit
 {
-    public class BenchmarkXUnit
+    public class BenchmarkNUnit
     {
         [Test]
         public void TestArray()
@@ -127,7 +126,7 @@ namespace Faultify.Benchmark.NUnit
         }
     }
 
-    public class BenchmarkXUnit1
+    public class BenchmarkNUnit1
     {
         [Test]
         public void TestArray()
@@ -251,7 +250,7 @@ namespace Faultify.Benchmark.NUnit
         }
     }
 
-    public class BenchmarkXUnit2
+    public class BenchmarkNUnit2
     {
         [Test]
         public void TestArray()
@@ -375,7 +374,7 @@ namespace Faultify.Benchmark.NUnit
         }
     }
 
-    public class BenchmarkXUnit3
+    public class BenchmarkNUnit3
     {
         [Test]
         public void TestArray()

--- a/Benchmark/Faultify.Benchmark.XUnit/BenchmarkXUnit.cs
+++ b/Benchmark/Faultify.Benchmark.XUnit/BenchmarkXUnit.cs
@@ -1,5 +1,5 @@
-using Faultify.Benchmark_0;
 using Xunit;
+//[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 namespace Faultify.Benchmark.XUnit
 {

--- a/Benchmark/Faultify.Benchmark/BenchmarkTarget.cs
+++ b/Benchmark/Faultify.Benchmark/BenchmarkTarget.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Faultify.Benchmark_0
+namespace Faultify.Benchmark
 {
     public class BenchmarkTarget
     {

--- a/Faultify.Injection/CoverageRegistry.cs
+++ b/Faultify.Injection/CoverageRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using Faultify.TestRunner.Shared;
 
 namespace Faultify.Injection
@@ -14,6 +15,7 @@ namespace Faultify.Injection
         private static readonly MutationCoverage MutationCoverage = new MutationCoverage();
         private static string _currentTestCoverage = "NONE";
         private static readonly object RegisterMutex = new object();
+        private static readonly object SetCoverageTestMutex = new object();
 
         /// <summary>
         ///     Is injected into <Module> by <see cref="TestCoverageInjector" /> and will be called on assembly load.
@@ -46,6 +48,7 @@ namespace Faultify.Injection
         {
             lock (RegisterMutex)
             {
+                File.AppendAllText("debug.txt", $"\tRegister Target {_currentTestCoverage}: {assemblyName}.{entityHandle} {Thread.CurrentThread.ManagedThreadId}\n");
                 try
                 {
                     if (!MutationCoverage.Coverage.TryGetValue(_currentTestCoverage, out var targetHandles))
@@ -60,9 +63,6 @@ namespace Faultify.Injection
                 {
                     // ignored
                 }
-
-                //OnCurrentDomain_ProcessExit(null, null);
-                File.AppendAllText("debug.txt", "\t out lock\n");
             }
         }
 
@@ -72,7 +72,11 @@ namespace Faultify.Injection
         /// <param name="testName"></param>
         public static void RegisterTestCoverage(string testName)
         {
-            _currentTestCoverage = testName;
+            lock (RegisterMutex)
+            {
+                File.AppendAllText("debug.txt", $"\tRegister Test Name {testName} {Thread.CurrentThread.ManagedThreadId}\n");
+                _currentTestCoverage = testName;
+            }
         }
     }
 }

--- a/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
+++ b/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
@@ -98,7 +98,10 @@ namespace Faultify.TestRunner.Dotnet
             {
                 var coverageProcessRunner = BuildCodeCoverageTestProcessRunner();
                 var process = await coverageProcessRunner.RunAsync();
-                _logger.LogDebug(coverageProcessRunner.Output.ToString());
+
+                var output = coverageProcessRunner.Output.ToString();
+
+                _logger.LogDebug(output);
                 _logger.LogError(coverageProcessRunner.Error.ToString());
 
                 if (process.ExitCode != 0) throw new ExitCodeException(process.ExitCode);

--- a/Faultify.TestRunner/Faultify.TestRunner.csproj
+++ b/Faultify.TestRunner/Faultify.TestRunner.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicator.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicator.cs
@@ -90,7 +90,7 @@ namespace Faultify.TestRunner.ProjectDuplication
 
             return testProjectDuplications;
         }
-
+        
         private static void CopyFilesRecursively(DirectoryInfo source, DirectoryInfo target)
         {
             foreach (var dir in source.GetDirectories())

--- a/Faultify.TestRunner/TestProjectLoader.cs
+++ b/Faultify.TestRunner/TestProjectLoader.cs
@@ -7,6 +7,7 @@ namespace Faultify.TestRunner
 {
     public class TestProjectInfo : IDisposable
     {
+        public TestFramework TestFramework { get; set; }
         public ModuleDefinition TestModule { get; set; }
         public List<AssemblyMutator> DependencyAssemblies { get; set; } = new List<AssemblyMutator>();
 

--- a/Faultify.sln.DotSettings.user
+++ b/Faultify.sln.DotSettings.user
@@ -19,12 +19,12 @@
     &lt;Project Location="E:\programming\FaultifyNew\Faultify\Benchmark\Faultify.Benchmark.MSTest" Presentation="&amp;lt;Benchmark&amp;gt;\&amp;lt;Faultify.Benchmark.MSTest&amp;gt;" /&gt;&#xD;
   &lt;/Or&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=32a3a768_002Db6da_002D4330_002D8cc9_002D95f92b9fb31e/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Arithmetic_PostMutation_MinToPlus" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=32a3a768_002Db6da_002D4330_002D8cc9_002D95f92b9fb31e/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Arithmetic_PostMutation_MinToPlus" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
     &lt;TestId&gt;NUnit3x::CBF4B950-7AA2-47A1-852E-A31A175E1114::.NETCoreApp,Version=v3.1::Faultify.Benchmark.Nunit.BenchmarkNUnit&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=cb050727_002Dc0ea_002D48a4_002D8178_002D166995f6c472/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="HasTwoMethodMutations_False" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=cb050727_002Dc0ea_002D48a4_002D8178_002D166995f6c472/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="HasTwoMethodMutations_False" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Or&gt;&#xD;
     &lt;Project Location="E:\programming\FaultifyNew\Faultify\Faultify.Tests" Presentation="&amp;lt;Faultify.Tests&amp;gt;" /&gt;&#xD;
     &lt;Project Location="E:\programming\FaultifyNew\Faultify\Benchmark\Faultify.Benchmark.NUnit" Presentation="&amp;lt;Benchmark&amp;gt;\&amp;lt;Faultify.Benchmark.NUnit&amp;gt;" /&gt;&#xD;


### PR DESCRIPTION
* Disable parallel code coverage XUnit.
* Forward Log data collectors to log files. 
* Fix namespaces benchmark projects.

XUNIT tests were run in parallel by default. Because of this, our coverage detection mechanism did not work. 

Three ways to disable parallel test runs:
- Run settings (requires dotnet test commandline argument)
- Via assembly attributes (requires code injection)
- Via `xunit.runner.json` settings. 

Run settings dit not seem to have any effect on preventing parallelization. I have not tried code injection. I fixed it by creating a json `xunit.runner.json` settings if the test framework is xunit.
